### PR TITLE
:knife: Add compat to image_push for old Skopeo

### DIFF
--- a/functions/core
+++ b/functions/core
@@ -19,7 +19,7 @@ function success() {
 }
 
 function failure() {
-    printf "${yellow}\xF0\x9F\x97\xB6${normal}${bold}${red} ERROR ${normal}"
+    printf "${yellow}\xE2\x9D\x95${normal}${bold}${red}ERROR ${normal}"
 }
 
 function info() {
@@ -115,9 +115,22 @@ _chart_pull() {
 }
 
 _image_push(){
-    local destination="${1}"
-    local image_dir="${2}"
-    local credential_file="${3}"
+    local destination="${1}" && shift
+    local image_dir="${1}" && shift
+    local credential_file="${1}" && shift
+    local compatibility_mode="${1}" && shift
+    local images=($@)
+
+    if [[ "${compatibility_mode}" == 'true' ]]; then
+        info && echo "Outdated version of skopeo installed. Running in compatibility mode."
+        for element in ${images[@]}; do
+            local image_name="${element##*/}"
+            skopeo --insecure-policy copy \
+                --authfile "${credential_file}" \
+                dir:"${element}" docker://"${destination}/${image_name}" && success
+            return 0
+        done
+    fi
 
     skopeo sync \
         --authfile "${credential_file}" \
@@ -149,12 +162,32 @@ jq_encode() {
     echo "${row}" | base64 --decode | jq -r "${key}"
 }
 
-validate_image_dir() {
+enumerate_image_dir() {
     local image_dir="${1}"
 
     [[ ! -d "${image_dir}" ]] && return 1
     dirs=$(find "${image_dir}" -maxdepth 1 -mindepth 1 -type d)
     [[ -z "${dirs}" ]] && return 1
+
+    echo "${dirs}"
+}
+
+function skopeo_current_version() {
+    local version_output=($(skopeo --version))
+    echo "${version_output[-1]}"
+}
+
+function version() {
+    awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }' <(echo "$@")
+}
+
+function version_check(){
+    local installed_version="${1}"
+    local expected_version="${2}"
+
+    if [[ $(version "${installed_version}") -le $(version "${expected_version}") ]]; then
+        return 1
+    fi
 
     return 0
 }

--- a/tac-fed
+++ b/tac-fed
@@ -30,6 +30,7 @@ IMAGE_ARCHIVE="${IMAGE_DIR}.tgz"
 TAC_CREDENTIAL_FILE="${CACHE_DIR}/tac-auth.json"
 PRIVATE_REGISTRY_CREDENTIAL_FILE="${CACHE_DIR}/private-registry-auth.json"
 HELM_REGISTRY_CONFIG="${TAC_CREDENTIAL_FILE}"
+SKOPEO_VERSION_THRESHOLD="${SKOPEO_VERSION_THRESHOLD:-0.1.41}"
 [[ -z "${TAC_URI:-}" ]] && TAC_URI="registry.pivotal.io"
 
 export HELM_EXPERIMENTAL_OCI
@@ -236,15 +237,21 @@ chart_pull() {
 
 image_push() {
     local destination="${1}"
+    local skopeo_compatibility_mode=false
     local dirs=()
 
-    info && echo "validating that ${IMAGE_DIR} is not empty."
-    if ! validate_image_dir "${IMAGE_DIR}"; then
+    info && echo "Validating that ${IMAGE_DIR} is not empty."
+    if ! enumerate_image_dir "${IMAGE_DIR}"; then
         failure && echo "${bold}${IMAGE_DIR}${normal} is empty or nonexistent. Please pull images prior."
         exit 1
     fi
+    dirs=$(enumerate_image_dir "${IMAGE_DIR}")
     success
-    _image_push "${destination}" "${IMAGE_DIR}" "${PRIVATE_REGISTRY_CREDENTIAL_FILE}"
+
+    if ! version_check $(skopeo_current_version) "${SKOPEO_VERSION_THRESHOLD}"; then
+        skopeo_compatibility_mode=true
+    fi
+    _image_push "${destination}" "${IMAGE_DIR}" "${PRIVATE_REGISTRY_CREDENTIAL_FILE}" "${skopeo_compatibility_mode}" "${dirs[@]}"
     push_summary "image" "${destination}"
 }
 


### PR DESCRIPTION
TL;DR
=====
- An updated version of Skopeo isn't always available; ¯\\\_(ツ)_/¯
- Allow `image_push` to go into compatibility mode and do `copy`
  operations instead of `sync` if the image is less than v0.1.41

Detail
======
We wanted to be able to **still** push images to a registry _if_ the
version of Skopeo wasn't new enough to contain the `sync` feature. This,
by no means, is a replacement for `sync`. In fact, it is brittle, as it
isn't comparable to the routine that `sync` uses. More than anything,
this is something to unblock someone that may be in the predicament of
not being able to pull down an updated version of Skopeo.

Signed-off-by: Conzetti Finocchiaro <conzetti@gmail.com>